### PR TITLE
readme updated: about/background/how it works/architecture/tech stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,57 @@
-# POC E2E Demo
+# Kudos Portal
 
 ## About
 
-This demonstration showcases Kudos Ink! Proof of Concept (POC), developed during the ["Polkadot Ink! Hackathon"](https://www.blog.encode.club/polkadot-ink-hackathon-powered-by-encode-club-prizewinners-and-summary-0ee9efac42ea) powered by the Encode Club. We proposed an automated contribution reward services using custom smart contracts and Github Workflows. For more details on how it works, here is the [finale winning pitch](https://www.youtube.com/watch?v=zw07lCW639w).
+Kudos Portal is a platform that onboards new contributors to the Substrate, Polkadot & Kusama ecosytem. It serves as an ideal hub for these communities to showcase their projects and encourage learning and discovery among developers. This solution integrates seamlessly with your GitHub projects, benefiting from a trustless, automated reward system that allows you to tag issues with custom incentives. Be it bounties, POAPs, or other utilities, the choice is yours. Developers are attracted to tasks matching their skill sets and interests, and upon completion, our trustless system ensures they are rewarded without any middlemen. The customization stems from our ink! smart contract templates and GitHub workflows, which automate the process.
+
+## Background
+
+After leaving the Polkadot Blockchain Academy, alumni find it challenging to locate GitHub issues to continue learning and contributing. This problem, which we have personally encountered, is a common struggle in the open-source software ecosystem. Additionally, incentivizing contributions could attract new developers to build on the ecosystem. However, no solution providing a trustless environment where contributors can receive their dues without intermediaries exists. Be it for reward distribution or for monitoring and reputation.
+
+We showcased a proof of concept (POC) of this project at the [Polkadot ink! hackathon](https://www.encode.club/polkadot-ink-hackathon), winning the main prize and additional sponsor awards two weeks ago. Here is our 3-minute [finale pitch](https://www.youtube.com/watch?v=zw07lCW639w). Today, we are maintaining this momentum by participating in the [Encode accelerator program](https://www.encode.club/encode-polkadot-accelerator-2023).
+
+## How it works?
+
+The contribution flow relies on two main characters:
+- An `organization` (or `project maintainer`) calling for contributors to address certain Github issues. 
+- `Aspiring contributors`
+
+### Step 0: Prerequisities
+
+- The organization connects to the Kudos Portal and marks some of its existing Github project as `Looking for contributors`.
+- Optionnally the organization can tag some project's issues with custom incentives from the portal. It instantiates a **reward contract** based on available contract templates from our [Kudos Factory](https://github.com/kudos-ink/contracts) or specifying a custom one. The custom contract needs to implement the interface defined by the [workflow trait](https://github.com/kudos-ink/contracts/blob/main/contracts/src/traits/workflow.rs). The first time a **reward contract** is added to a project contribution, a pull request (PR) is automatically opened on the Github repository of the project adding the corresponding workflow.
+
+### Step 1: Aspiring Contributor
+
+- An aspiring finds an available contribution on the Kudos Portal. After being assigned it, he starts working on it.
+- The contributor opens a PR to resolve the issue specifying its address.
+
+### Step 2: Approval
+
+- The organization reviews, approves, and merges the PR, thereby closing the issue.
+- The **reward workflow** is triggered and calls `approve` on the **reward contract** with the given issue #ID and the contributor address.
+
+### Step 3: Claim
+
+- The contributor claims its reward from the Kudos Portal by using the `claim` method on the **reward contract** with the issue #ID. This action triggers the custom reward flow specified in the contract (e.g. a single bounty transfer, an NFT minting, ..)
+
+## Architecture
+
+### Customization aspects
+
+This approach offers a high level of customization. The `claim` method, the final step in the process, allows for a wide range of reward mechanisms, making it highly adaptable to the specific needs and preferences of the organization and contributors. This flexibility empowers projects to implement diverse and tailored reward structures, whether it's a straightforward balance transfer, the issuance of non-fungible tokens (NFTs), or other creative and unique reward systems, ensuring that the Kudos Ink! platform can seamlessly accommodate a variety of open-source project needs and preferences. 
+
+Kudos Ink! provides some templates ready to use as [reward workflow](https://github.com/kudos-ink/workflow-example/blob/main/.github/workflows/issue-closed.yml) with dedicated Github actions and [reward contract](https://github.com/kudos-ink/contracts/blob/main/contracts/src/token/single-token/lib.rs)
+
+## Tech Stack
+
+### Open brush support
+
+Kudos Ink! supports [OpenBrush](https://github.com/Brushfam/openbrush-contracts). The `approve` method extends the [Ownable](https://learn.brushfam.io/docs/OpenBrush/smart-contracts/ownable) contract from OpenBrush.
+
+### ink!athon Boilerplate
+
+This project uses the [ink!athon Boilerplate](https://github.com/scio-labs/inkathon) full-stack dApp boilerplate for ink! smart contracts with an integrated frontend.
 
 ## Use this demo
 
@@ -13,7 +62,7 @@ Below is the detailed workflow:
 
 #### Steps:
 
-1. Connect and register your identity (e.g. Github handle) in the Demo UI app.
+1. Connect and spot an available contribution on the Kudos Portal.
 
    This action marks your intention to contribute to a project. In this case, to test the demo.
 
@@ -23,6 +72,6 @@ Below is the detailed workflow:
 
 4. Finally, check your contribution status, marked as complete, in the Demo UI app.
 
-## Stack: ink!athon Boilerplate
+## Next steps
 
-This project uses the [ink!athon Boilerplate](https://github.com/scio-labs/inkathon) full-stack dApp boilerplate for ink! smart contracts with an integrated frontend.
+The Kudos team has dedicated itself to developing within the Polkadot ecosystem over recent months. Our aim is for the community to recognize the significance of our upcoming project. We eagerly welcome feedback and are readily available to address any inquiries. Looking forward to connecting soon!


### PR DESCRIPTION
Some ideas missing:

- Stakeholders
- Explanation overview & details
- Getting started: prerequisites guidelines for projects integration & developers onboard.
- Contribution guidelines (meta concept of Kudos vision within our projects: our own project could in fact be one of the first utilisers of the open source contributor pool we create)

> We don’t have money to offer at the moment, but POAP’s, would be great. The POAP’s we offer don’t have to just be symbolic either, they could have real value and utility. Just thinking out loud, but for instance we could issue POAP’s for contributions to Kudos which are limited in number, and which offer some enhancement to their experience, like early access to register as contributors when new issues pop up on our platform.

- Research Notes (contribution market, identity registration, economy & game theory)